### PR TITLE
add client options for skip updating emotesets

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -37,6 +37,7 @@ export default class App extends Vue {
         password: state.BOT_SETTINGS.OAUTH_TOKEN,
       },
       channels: [state.BOT_SETTINGS.CHANNEL_NAME],
+      options: { skipUpdatingEmotesets: true },
     });
 
     const shoutout = async function (channel: string, loginName: string) {


### PR DESCRIPTION
emoticon で 404 エラーが出る問題で、おそらくですが localhost からの CORS かと思われますが、
エモートセットをアップデートするリクエストでエラー出てるので
BOT の機能的に現段階では emoteset のアップデートリクエストはいらなさそうなのでそれをオフにするオプションを付け足してコンソールにエラーが出ないようにしました

いちおうですが PR 出しておきます〜

蛇足：tmi.js のエモートセットを update する部分、ふつうにドメインがハードコードされていて、外から書き換えられないのでプロキシ利用して回避しようとしましたができませんでした 😇 